### PR TITLE
Release 0.1.4: fix dashboard to show database-level metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-05-13
+
+### Fixed
+
+- **Dashboard: database-level metrics** — Dashboard now shows CPU/memory/storage/network for the active database (`/viewer/json/tenantinfo?path=<db>`) instead of cluster-wide metrics. CPU total is derived from `PoolStats.Threads`; tenant is selected by `Name` when the response lists multiple
+
 ## [0.1.3] - 2026-05-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ydb-vscode-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ydb-vscode-plugin",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.0",
         "@gravity-ui/websql-autocomplete": "^13.14.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ydb-vscode-plugin",
   "displayName": "YDB for VS Code",
   "description": "YDB database support for Visual Studio Code",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "ydb-tech",
   "icon": "assets/icon.png",
   "repository": {

--- a/src/commands/viewCommands.ts
+++ b/src/commands/viewCommands.ts
@@ -113,7 +113,7 @@ async function showDashboard(connectionManager: ConnectionManager): Promise<void
             } catch {
                 queryService = undefined;
             }
-            const metrics = await fetchDashboardMetrics(monitoringUrl, authClient, queryService);
+            const metrics = await fetchDashboardMetrics(monitoringUrl, profile.database, authClient, queryService);
             dashboardPanel.webview.postMessage({ type: 'dashboardData', metrics });
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
@@ -127,17 +127,18 @@ async function showDashboard(connectionManager: ConnectionManager): Promise<void
 
 export async function fetchDashboardMetrics(
     monitoringUrl: string,
+    database: string,
     authClient: MonitoringAuthClient,
     queryService?: QueryService,
 ): Promise<DashboardMetrics> {
-    const viewerUrl = `${monitoringUrl}/viewer/json/cluster`;
+    const viewerUrl = `${monitoringUrl}/viewer/json/tenantinfo?path=${encodeURIComponent(database)}`;
 
-    const [clusterData, runningQueries] = await Promise.all([
+    const [tenantData, runningQueries] = await Promise.all([
         authClient.httpGet(viewerUrl),
         fetchRunningQueriesCount(queryService),
     ]);
 
-    const json = JSON.parse(clusterData);
+    const json = JSON.parse(tenantData);
 
     const metrics: DashboardMetrics = {
         cpuUsed: 0,
@@ -150,27 +151,35 @@ export async function fetchDashboardMetrics(
         runningQueries,
     };
 
-    // Parse cluster-level metrics (values come as strings from YDB Viewer API)
-    if (json.CoresUsed !== undefined) {
-        metrics.cpuUsed = parseFloat(String(json.CoresUsed)) || 0;
+    const tenants = Array.isArray(json.TenantInfo) ? json.TenantInfo : [];
+    const tenant = tenants.find((t: { Name?: string }) => t?.Name === database) ?? tenants[0];
+    if (!tenant) {
+        return metrics;
     }
-    if (json.CoresTotal !== undefined) {
-        metrics.cpuTotal = parseFloat(String(json.CoresTotal)) || 0;
+
+    if (tenant.CoresUsed !== undefined) {
+        metrics.cpuUsed = parseFloat(String(tenant.CoresUsed)) || 0;
     }
-    if (json.MemoryUsed !== undefined) {
-        metrics.memoryUsed = parseInt(String(json.MemoryUsed), 10) || 0;
+    if (Array.isArray(tenant.PoolStats)) {
+        metrics.cpuTotal = tenant.PoolStats.reduce(
+            (acc: number, pool: { Threads?: unknown }) => acc + (Number(pool?.Threads) || 0),
+            0,
+        );
     }
-    if (json.MemoryTotal !== undefined) {
-        metrics.memoryTotal = parseInt(String(json.MemoryTotal), 10) || 0;
+    if (tenant.MemoryUsed !== undefined) {
+        metrics.memoryUsed = parseInt(String(tenant.MemoryUsed), 10) || 0;
     }
-    if (json.StorageUsed !== undefined) {
-        metrics.storageUsed = parseInt(String(json.StorageUsed), 10) || 0;
+    if (tenant.MemoryLimit !== undefined) {
+        metrics.memoryTotal = parseInt(String(tenant.MemoryLimit), 10) || 0;
     }
-    if (json.StorageTotal !== undefined) {
-        metrics.storageTotal = parseInt(String(json.StorageTotal), 10) || 0;
+    if (tenant.StorageAllocatedSize !== undefined) {
+        metrics.storageUsed = parseInt(String(tenant.StorageAllocatedSize), 10) || 0;
     }
-    if (json.NetworkWriteThroughput !== undefined) {
-        metrics.networkThroughput = parseFloat(String(json.NetworkWriteThroughput)) || 0;
+    if (tenant.StorageAllocatedLimit !== undefined) {
+        metrics.storageTotal = parseInt(String(tenant.StorageAllocatedLimit), 10) || 0;
+    }
+    if (tenant.NetworkWriteThroughput !== undefined) {
+        metrics.networkThroughput = parseFloat(String(tenant.NetworkWriteThroughput)) || 0;
     }
 
     return metrics;

--- a/src/test/commands/fetchDashboardMetrics.test.ts
+++ b/src/test/commands/fetchDashboardMetrics.test.ts
@@ -20,25 +20,41 @@ function makeServer(
     });
 }
 
-const clusterPayload = JSON.stringify({
-    CoresUsed: '4.5',
-    CoresTotal: '8',
-    MemoryUsed: '1073741824',
-    MemoryTotal: '8589934592',
-    StorageUsed: '500',
-    StorageTotal: '1000',
-    NetworkWriteThroughput: '0',
-});
+const DATABASE = '/Root/my-db';
+
+function tenantInfoPayload(extra: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+        TenantInfo: [
+            {
+                Name: DATABASE,
+                CoresUsed: 1.25,
+                MemoryUsed: '1073741824',
+                MemoryLimit: '8589934592',
+                StorageAllocatedSize: '500',
+                StorageAllocatedLimit: '1000',
+                NetworkWriteThroughput: '0',
+                PoolStats: [
+                    { Name: 'System', Threads: 2, Usage: 0.1 },
+                    { Name: 'User', Threads: 4, Usage: 0.3 },
+                    { Name: 'Batch', Threads: 2, Usage: 0.0 },
+                ],
+                ...extra,
+            },
+        ],
+    });
+}
 
 describe('fetchDashboardMetrics', () => {
     let teardown: Array<() => Promise<void>> = [];
     beforeEach(() => { teardown = []; });
     afterEach(async () => { for (const fn of teardown) {await fn();} });
 
-    it('returns runningQueries from queryService', async () => {
-        const server = await makeServer((_req, res) => {
+    it('requests tenantinfo with database path and parses tenant-level metrics', async () => {
+        let requestedUrl = '';
+        const server = await makeServer((req, res) => {
+            requestedUrl = req.url ?? '';
             res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(clusterPayload);
+            res.end(tenantInfoPayload());
         });
         teardown.push(server.close);
 
@@ -52,28 +68,78 @@ describe('fetchDashboardMetrics', () => {
 
         const base = `http://127.0.0.1:${server.port}`;
         const auth = new MonitoringAuthClient(base);
-        const m = await fetchDashboardMetrics(base, auth, fakeQs);
+        const m = await fetchDashboardMetrics(base, DATABASE, auth, fakeQs);
+
+        expect(requestedUrl).toBe(`/viewer/json/tenantinfo?path=${encodeURIComponent(DATABASE)}`);
+        expect(m.cpuUsed).toBe(1.25);
+        expect(m.cpuTotal).toBe(8); // sum of PoolStats.Threads (2+4+2)
+        expect(m.memoryUsed).toBe(1073741824);
+        expect(m.memoryTotal).toBe(8589934592);
+        expect(m.storageUsed).toBe(500);
+        expect(m.storageTotal).toBe(1000);
+        expect(m.networkThroughput).toBe(0);
         expect(m.runningQueries).toBe(7);
-        expect(m.cpuUsed).toBe(4.5);
-        expect(m.cpuTotal).toBe(8);
+    });
+
+    it('picks tenant by Name when multiple tenants returned', async () => {
+        const payload = JSON.stringify({
+            TenantInfo: [
+                {
+                    Name: '/Root/other',
+                    CoresUsed: 99,
+                    PoolStats: [{ Name: 'User', Threads: 99 }],
+                },
+                {
+                    Name: DATABASE,
+                    CoresUsed: 2,
+                    PoolStats: [{ Name: 'User', Threads: 4 }],
+                },
+            ],
+        });
+        const server = await makeServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(payload);
+        });
+        teardown.push(server.close);
+
+        const base = `http://127.0.0.1:${server.port}`;
+        const auth = new MonitoringAuthClient(base);
+        const m = await fetchDashboardMetrics(base, DATABASE, auth);
+        expect(m.cpuUsed).toBe(2);
+        expect(m.cpuTotal).toBe(4);
+    });
+
+    it('returns zeros when TenantInfo is empty', async () => {
+        const server = await makeServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ TenantInfo: [] }));
+        });
+        teardown.push(server.close);
+        const base = `http://127.0.0.1:${server.port}`;
+        const auth = new MonitoringAuthClient(base);
+        const m = await fetchDashboardMetrics(base, DATABASE, auth);
+        expect(m.cpuUsed).toBe(0);
+        expect(m.cpuTotal).toBe(0);
+        expect(m.memoryUsed).toBe(0);
+        expect(m.storageUsed).toBe(0);
     });
 
     it('returns 0 runningQueries when queryService is undefined', async () => {
         const server = await makeServer((_req, res) => {
             res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(clusterPayload);
+            res.end(tenantInfoPayload());
         });
         teardown.push(server.close);
         const base = `http://127.0.0.1:${server.port}`;
         const auth = new MonitoringAuthClient(base);
-        const m = await fetchDashboardMetrics(base, auth);
+        const m = await fetchDashboardMetrics(base, DATABASE, auth);
         expect(m.runningQueries).toBe(0);
     });
 
     it('returns 0 runningQueries when query throws', async () => {
         const server = await makeServer((_req, res) => {
             res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(clusterPayload);
+            res.end(tenantInfoPayload());
         });
         teardown.push(server.close);
         const fakeQs = {
@@ -81,14 +147,14 @@ describe('fetchDashboardMetrics', () => {
         } as unknown as QueryService;
         const base = `http://127.0.0.1:${server.port}`;
         const auth = new MonitoringAuthClient(base);
-        const m = await fetchDashboardMetrics(base, auth, fakeQs);
+        const m = await fetchDashboardMetrics(base, DATABASE, auth, fakeQs);
         expect(m.runningQueries).toBe(0);
     });
 
     it('handles bigint Cnt value', async () => {
         const server = await makeServer((_req, res) => {
             res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(clusterPayload);
+            res.end(tenantInfoPayload());
         });
         teardown.push(server.close);
         const fakeQs = {
@@ -100,7 +166,22 @@ describe('fetchDashboardMetrics', () => {
         } as unknown as QueryService;
         const base = `http://127.0.0.1:${server.port}`;
         const auth = new MonitoringAuthClient(base);
-        const m = await fetchDashboardMetrics(base, auth, fakeQs);
+        const m = await fetchDashboardMetrics(base, DATABASE, auth, fakeQs);
         expect(m.runningQueries).toBe(3);
+    });
+
+    it('properly encodes special characters in database path', async () => {
+        let requestedUrl = '';
+        const server = await makeServer((req, res) => {
+            requestedUrl = req.url ?? '';
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ TenantInfo: [] }));
+        });
+        teardown.push(server.close);
+        const base = `http://127.0.0.1:${server.port}`;
+        const auth = new MonitoringAuthClient(base);
+        const db = '/Root/db with spaces&special';
+        await fetchDashboardMetrics(base, db, auth);
+        expect(requestedUrl).toBe(`/viewer/json/tenantinfo?path=${encodeURIComponent(db)}`);
     });
 });

--- a/src/views/dashboardProvider.ts
+++ b/src/views/dashboardProvider.ts
@@ -175,7 +175,7 @@ export class DashboardProvider implements vscode.TreeDataProvider<vscode.TreeIte
         }
 
         try {
-            this.metrics = await fetchDashboardMetrics(monitoringUrl, this.authClient, queryService);
+            this.metrics = await fetchDashboardMetrics(monitoringUrl, profile.database, this.authClient, queryService);
             this.error = undefined;
         } catch (err: unknown) {
             this.error = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

- Fix: Dashboard showed cluster-wide load instead of the active database. Switched from `/viewer/json/cluster` to `/viewer/json/tenantinfo?path=<database>` and parse the matching `TTenant` entry (`CoresUsed`, `PoolStats.Threads` → `cpuTotal`, `MemoryUsed/Limit`, `StorageAllocatedSize/Limit`, `NetworkWriteThroughput`).
- Tenant is selected by `Name` when multiple are returned; falls back to the first entry.
- Adds integration tests with a local HTTP server (URL/encoding, field parsing, tenant-by-name selection, empty `TenantInfo`, query-service edge cases).
- Bumps version to `0.1.4`, updates `CHANGELOG.md`.

## Test plan

- [x] `./run-tests.sh` — 730/730 passing
- [ ] Manual: install VSIX, open Dashboard, confirm CPU/memory/storage match the database (not cluster) in the YDB Embedded UI
- [ ] Manual: switch active connection between databases — metrics update to match the newly selected database