### PR TITLE
Release 0.1.5: advertise extension in SDK build-info header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-06-09
+
+### Added
+
+- **SDK build-info advertising** — extension now registers itself with each YDB Driver via `kRegisterLibrary`, so the server sees `ydb-js-sdk/<sdk>;ydb-vscode-plugin/<version>` in the build-info header. All Driver creation is routed through a single `createDriver()` helper for consistent registration
+
+### Changed
+
+- **Bumped `@ydbjs/core` to ^6.3.1** (with matching `@ydbjs/auth` ^6.3.1 and `@ydbjs/api` ^6.0.7) — required for `kRegisterLibrary` support
+- **Declared runtime target aligned with @ydbjs** — `engines.vscode` raised to ^1.94.0 (first VS Code shipping Node 20 in Electron) and esbuild target raised to `node20`. The Node floor itself is not new — `@ydbjs` 6.0.x already required >=20.19.0 — the manifest now reflects it honestly
+
 ## [0.1.4] - 2026-05-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ydb-vscode-plugin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ydb-vscode-plugin",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.0",
         "@gravity-ui/websql-autocomplete": "^13.14.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ydb-vscode-plugin",
   "displayName": "YDB for VS Code",
   "description": "YDB database support for Visual Studio Code",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "publisher": "ydb-tech",
   "icon": "assets/icon.png",
   "repository": {


### PR DESCRIPTION
## Summary

- Register extension with each YDB Driver via `kRegisterLibrary` so server sees `ydb-vscode-plugin/<version>` in build-info
- Bump `@ydbjs/core` ^6.3.1, `@ydbjs/auth` ^6.3.1, `@ydbjs/api` ^6.0.7
- Align declared runtime: `engines.vscode` ^1.94.0, esbuild target `node20` (matches @ydbjs's existing Node >=20.19.0 requirement)

See CHANGELOG.md for the user-facing notes.

## Test plan

- [x] `./run-tests.sh` — 730 tests passed